### PR TITLE
Add blacklist option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,37 @@
 // @flow
 import WebpackMd5Hash from 'webpack-md5-hash'
 
-const isVendor = ({ userRequest }) => (
+type Blacklist = string | RegExp
+
+type Options = {
+  name: string,
+  blacklist?: Blacklist,
+}
+
+const match = (userRequest, matcher?: Blacklist) => {
+  if (!matcher) return true
+  if (matcher instanceof RegExp) return !userRequest.match(matcher)
+  return userRequest.indexOf(matcher) === -1
+}
+
+const isVendor = ({ blacklist }: Options) => ({ userRequest }) => (
   userRequest &&
   userRequest.indexOf('node_modules') >= 0 &&
-  userRequest.match(/\.js$/)
+  userRequest.match(/\.js$/) &&
+  match(userRequest, blacklist)
 )
 
 /**
  * Returns a webpack block that splits vendor javascript bundle.
  */
-const splitVendor = (name: string = 'vendor'): any => ({ webpack }) => ({
+const splitVendor = (name: string | Options = 'vendor'): any => ({ webpack }) => ({
   output: {
     filename: '[name].[chunkhash].js',
   },
   plugins: [
     new webpack.optimize.CommonsChunkPlugin({
-      minChunks: isVendor,
-      name,
+      minChunks: typeof name === 'object' ? isVendor(name) : isVendor({ name }),
+      name: typeof name === 'object' ? name.name : name,
     }),
     new WebpackMd5Hash(),
   ],


### PR DESCRIPTION
Since `offline-plugin` injects a runtime dependency that changes on each build, I needed a way to keep it out of the vendor bundle so the vendor chunkhash wouldn't change if it didn't need to.  This is what I came up with:

```js
splitVendor({
  name: 'vendor',
  blacklist: /(\/webpack\/hot\/|offline-plugin\/runtime\.js$)/,
})
```

(also excluding `webpack/hot` for HMR)

It probably could use some cleanup, but I wanted to run it by you first.

Edit:
Also, I kept it backwards compatible with:

```js
splitVendor('vendor')
```